### PR TITLE
fix: macros -> macro. ref #7

### DIFF
--- a/other/docs/author.md
+++ b/other/docs/author.md
@@ -2,14 +2,14 @@
 
 > See also: [the `user` docs](https://github.com/kentcdodds/babel-macros/blob/master/other/docs/user.md).
 
-## Writing a macros
+## Writing a macro
 
-A macros is a JavaScript module that exports a function. It can be published to
+A macro is a JavaScript module that exports a function. It can be published to
 the npm registry (for generic macros, like a css-in-js library) or used locally
 (for domain-specific macros, like handling some special case for your company's
 localization efforts).
 
-> Before you write a custom macros, you might consider whether
+> Before you write a custom macro, you might consider whether
 > [`babel-plugin-preval`][preval] help you do what you want as it's pretty
 > powerful.
 
@@ -20,52 +20,52 @@ There are two parts to the `babel-macros` API:
 
 **Filename**:
 
-The way that `babel-macros` determines whether to run a macros is based on the
+The way that `babel-macros` determines whether to run a macro is based on the
 source string of the `import` or `require` statement. It must match this regex:
-`/[./]macros(\.js)?$/` for example:
+`/[./]macro(\.js)?$/` for example:
 
 _matches_:
 
 ```
-'my.macros'
-'my.macros.js'
-'my/macros'
-'my/macros.js'
+'my.macro'
+'my.macro.js'
+'my/macro'
+'my/macro.js'
 ```
 
 _does not match_:
 
 ```
-'my-macros'
-'my.macros.is-sweet'
-'my/macros/rocks'
+'my-macro'
+'my.macro.is-sweet'
+'my/macro/rocks'
 ```
 
 > So long as your file can be required at a matching path, you're good. So you
-> could put it in: `my/macros/index.js` and people would: `require('my/macros')`
+> could put it in: `my/macro/index.js` and people would: `require('my/macro')`
 > which would work fine.
 
 **If you're going to publish this to npm,** the most ergonomic thing would be to
-name it something that ends in `.macros`. If it's part of a larger package,
-then calling the file `macros.js` or placing it in `macros/index.js` is a great
+name it something that ends in `.macro`. If it's part of a larger package,
+then calling the file `macro.js` or placing it in `macro/index.js` is a great
 way to go as well. Then people could do:
 
 ```js
-import Nice from 'nice.macros'
+import Nice from 'nice.macro'
 // or
-import Sweet from 'sweet/macros'
+import Sweet from 'sweet/macro'
 ```
 
 **Function API**:
 
-The macros you create should export a function. That function accepts a single
+The macro you create should export a function. That function accepts a single
 parameter which is an object with the following properties:
 
 **state**: The state of the file being traversed. It's the second argument
 you receive in a visitor function in a normal babel plugin.
 
 **references**: This is an object that contains arrays of all the references to
-things imported from macros keyed based on the name of the import. The items
+things imported from macro keyed based on the name of the import. The items
 in each array are the paths to the references.
 
 <details>
@@ -73,9 +73,9 @@ in each array are the paths to the references.
 <summary>Some examples:</summary>
 
 ```javascript
-import MyMacros from './my.macros'
+import MyMacro from './my.macro'
 
-MyMacros({someOption: true}, `
+MyMacro({someOption: true}, `
   some stuff
 `)
 
@@ -83,9 +83,9 @@ MyMacros({someOption: true}, `
 ```
 
 ```javascript
-import {foo as FooMacros} from './my.macros'
+import {foo as FooMacro} from './my.macro'
 
-FooMacros({someOption: true}, `
+FooMacro({someOption: true}, `
   some stuff
 `)
 
@@ -93,7 +93,7 @@ FooMacros({someOption: true}, `
 ```
 
 ```javascript
-import {foo as FooMacros} from './my.macros'
+import {foo as FooMacro} from './my.macro'
 
 // no usage...
 
@@ -105,13 +105,13 @@ import {foo as FooMacros} from './my.macros'
 From here, it's just a matter of doing doing stuff with the `BabelPath`s that
 you're given. For that check out [the babel handbook][babel-handbook].
 
-> One other thing to note is that after your macros has run, babel-macros will
+> One other thing to note is that after your macro has run, babel-macros will
 > remove the import/require statement for you.
 
 
-## Testing your macros
+## Testing your macro
 
-The best way to test your macros is using [`babel-plugin-tester`][tester]:
+The best way to test your macro is using [`babel-plugin-tester`][tester]:
 
 ```javascript
 import path from 'path'
@@ -123,9 +123,9 @@ pluginTester({
   snapshot: true,
   tests: withFilename([
     `
-      import MyMacros from '../my.macros'
+      import MyMacro from '../my.macro'
 
-      MyMacros({someOption: true}, \`
+      MyMacro({someOption: true}, \`
         some stuff
       \`)
     `
@@ -149,8 +149,8 @@ function withFilename(tests) {
 }
 ```
 
-There is currently no way to get code coverage for your macros this way however.
-If you want code coverage, you'll have to call your macros yourself.
+There is currently no way to get code coverage for your macro this way however.
+If you want code coverage, you'll have to call your macro yourself.
 Contributions to improve this experience are definitely welcome!
 
 [preval]: https://github.com/kentcdodds/babel-plugin-preval

--- a/other/docs/user.md
+++ b/other/docs/user.md
@@ -30,25 +30,25 @@ require('babel-core').transform('code', {
 
 ## Using a macros
 
-With the `babel-macros` plugin added to your config, we can now use a macros
+With the `babel-macros` plugin added to your config, we can now use a macro
 that works with the `babel-macros` API. Let's assume we have such a module
-in our project called `eval.macros.js`. To use it, we `import` or `require`
-the macros module in our code like so:
+in our project called `eval.macro.js`. To use it, we `import` or `require`
+the macro module in our code like so:
 
 ```javascript
-import MyEval from './eval.macros'
+import MyEval from './eval.macro'
 // or
-const MyEval = require('./eval.macros')
+const MyEval = require('./eval.macro')
 ```
 
-Then we use that variable however the documentation for the macros says.
-Incidentally, `eval.macros.js` actually exists in the tests for `babel-macros`
-[here][eval-macros] and you can see how it transforms our code in
+Then we use that variable however the documentation for the macro says.
+Incidentally, `eval.macro.js` actually exists in the tests for `babel-macros`
+[here][eval-macro] and you can see how it transforms our code in
 [the `babel-macros` snapshots][eval-snapshots].
 
 > Note here that the real benefit is that we don't need to configure anything
-> for every macros you add. We simply configure `babel-macros`, then we can
-> use any macros available. This is part of the benefit of using `babel-macros`.
+> for every macro you add. We simply configure `babel-macros`, then we can
+> use any macro available. This is part of the benefit of using `babel-macros`.
 
-[eval-macros]: https://github.com/kentcdodds/babel-macros/blob/master/src/__tests__/fixtures/eval.macros.js
+[eval-macro]: https://github.com/kentcdodds/babel-macros/blob/master/src/__tests__/fixtures/eval.macro.js
 [eval-snapshots]: https://github.com/kentcdodds/babel-macros/blob/master/src/__tests__/__snapshots__/index.js.snap

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -2,18 +2,18 @@
 
 exports[`2. does nothing but remove macros if it is unused 1`] = `
 
-import foo from "./some-macros-that-doesnt-even-need-to-exist.macros"
-export default "something else"
+import foo from './some-macros-that-doesnt-even-need-to-exist.macro'
+export default 'something else'
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-export default "something else";
+export default 'something else';
 
 `;
 
 exports[`3. works with import 1`] = `
 
-import myEval from './fixtures/eval.macros'
+import myEval from './fixtures/eval.macro'
 const x = myEval\`34 + 45\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -24,7 +24,7 @@ const x = 79;
 
 exports[`4. works with require 1`] = `
 
-const evaler = require('./fixtures/eval.macros')
+const evaler = require('./fixtures/eval.macro')
 const x = evaler\`34 + 45\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -35,7 +35,7 @@ const x = 79;
 
 exports[`5. works with function calls 1`] = `
 
-import myEval from './fixtures/eval.macros'
+import myEval from './fixtures/eval.macro'
 const x = myEval('34 + 45')
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -46,7 +46,7 @@ const x = 79;
 
 exports[`6. Works as a JSXElement 1`] = `
 
-import MyEval from './fixtures/eval.macros'
+import MyEval from './fixtures/eval.macro'
 const x = <MyEval>34 + 45</MyEval>
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -57,7 +57,7 @@ const x = 79;
 
 exports[`7. Supports named imports 1`] = `
 
-import {css as CSS, styled as STYLED} from './fixtures/emotion.macros'
+import {css as CSS, styled as STYLED} from './fixtures/emotion.macro'
 const red = CSS\`
   background-color: red;
 \`

--- a/src/__tests__/fixtures/emotion.macro.js
+++ b/src/__tests__/fixtures/emotion.macro.js
@@ -2,7 +2,9 @@ const t = require('babel-types')
 // this is a fake version of emotion
 // const printAST = require('ast-pretty-print')
 
-module.exports = function emotionMacros({references}) {
+module.exports = emotionMacro
+
+function emotionMacro({references}) {
   references.css.forEach(cssRef => {
     if (cssRef.parentPath.type === 'TaggedTemplateExpression') {
       cssRef.parentPath.replaceWith(

--- a/src/__tests__/fixtures/eval.macro.js
+++ b/src/__tests__/fixtures/eval.macro.js
@@ -1,9 +1,9 @@
 const babylon = require('babylon')
 // const printAST = require('ast-pretty-print')
 
-module.exports = evalMacros
+module.exports = evalMacro
 
-function evalMacros({references, state}) {
+function evalMacro({references, state}) {
   references.default.forEach(referencePath => {
     if (referencePath.parentPath.type === 'TaggedTemplateExpression') {
       asTag(referencePath.parentPath.get('quasi'), state)

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -20,52 +20,52 @@ pluginTester({
   snapshot: true,
   tests: withFilename([
     {
-      title: 'does nothing to code that does not import macros',
+      title: 'does nothing to code that does not import macro',
       snapshot: false,
       code: `
-        import foo from './some-file-without-macros';
-        const bar = require('./some-other-file-without-macros');
+        import foo from './some-file-without-macro';
+        const bar = require('./some-other-file-without-macro');
       `,
     },
     {
       title: 'does nothing but remove macros if it is unused',
       code: `
-        import foo from "./some-macros-that-doesnt-even-need-to-exist.macros"
-        export default "something else"
+        import foo from './some-macros-that-doesnt-even-need-to-exist.macro'
+        export default 'something else'
       `,
     },
     {
       title: 'works with import',
       code: `
-        import myEval from './fixtures/eval.macros'
+        import myEval from './fixtures/eval.macro'
         const x = myEval\`34 + 45\`
       `,
     },
     {
       title: 'works with require',
       code: `
-        const evaler = require('./fixtures/eval.macros')
+        const evaler = require('./fixtures/eval.macro')
         const x = evaler\`34 + 45\`
       `,
     },
     {
       title: 'works with function calls',
       code: `
-        import myEval from './fixtures/eval.macros'
+        import myEval from './fixtures/eval.macro'
         const x = myEval('34 + 45')
       `,
     },
     {
       title: 'Works as a JSXElement',
       code: `
-        import MyEval from './fixtures/eval.macros'
+        import MyEval from './fixtures/eval.macro'
         const x = <MyEval>34 + 45</MyEval>
       `,
     },
     {
       title: 'Supports named imports',
       code: `
-        import {css as CSS, styled as STYLED} from './fixtures/emotion.macros'
+        import {css as CSS, styled as STYLED} from './fixtures/emotion.macro'
         const red = CSS\`
           background-color: red;
         \`

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const p = require('path')
 // const printAST = require('ast-pretty-print')
 
-const macrosRegex = /[./]macros(\.js)?$/
+const macrosRegex = /[./]macro(\.js)?$/
 
 module.exports = macrosPlugin
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: changes `macros` in the regex to `macro`

<!-- Why are these changes necessary? -->
**Why**: Because you're actually only importing a single `macro`.

<!-- How were these changes implemented? -->
**How**: Mostly the regex, but also update the docs to reference a single `macro` rather than `macros`.


<!-- feel free to add additional comments -->
