### PR TITLE
fix: requirePath can now work with absolute/node_modules paths

### DIFF
--- a/__mocks__/fake/macro.js
+++ b/__mocks__/fake/macro.js
@@ -1,0 +1,2 @@
+// this is used to make sure that you can require macro from node_modules
+module.exports = jest.fn()

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -74,3 +74,14 @@ const red = 'background-color: red;';
 const Div = STYLED.div\`undefined\`;
 
 `;
+
+exports[`8. supports macros from node_modules 1`] = `
+
+import fakeMacro from 'fake/macro'
+fakeMacro('hi')
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+fakeMacro('hi');
+
+`;

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,6 +1,12 @@
 import path from 'path'
+// eslint-disable-next-line
+import fakeMacro from 'fake/macro';
 import pluginTester from 'babel-plugin-tester'
 import plugin from '../'
+
+afterEach(() => {
+  fakeMacro.mockClear()
+})
 
 const projectRoot = path.join(__dirname, '../../')
 
@@ -75,6 +81,22 @@ pluginTester({
           color: blue;
         \`
       `,
+    },
+    {
+      title: 'supports macros from node_modules',
+      code: `
+        import fakeMacro from 'fake/macro'
+        fakeMacro('hi')
+      `,
+      teardown() {
+        // kinda abusing the babel-plugin-tester API here
+        // to make an extra assertion
+        expect(fakeMacro).toHaveBeenCalledTimes(1)
+        expect(fakeMacro).toHaveBeenCalledWith({
+          references: expect.any(Object),
+          state: expect.any(Object),
+        })
+      },
     },
   ]),
 })

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,11 @@ function applyMacros({path, imports, source, state}) {
   if (!hasReferences) {
     return
   }
-  const requirePath = p.join(p.dirname(filename), source)
+  let requirePath = source
+  const isRelative = source.indexOf('.') === 0
+  if (isRelative) {
+    requirePath = p.join(p.dirname(filename), source)
+  }
   // eslint-disable-next-line import/no-dynamic-require
   const macros = require(requirePath)
   macros({


### PR DESCRIPTION
closes #16

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Checks for relative path if the path starts with `.`

<!-- Why are these changes necessary? -->
**Why**: To fix #16 

<!-- How were these changes implemented? -->
**How**: using `indexOf` because technically we support Node v4 I guess.


<!-- feel free to add additional comments -->
