### PR TITLE
feat: forward babel to the macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@
 [![Star on GitHub][github-star-badge]][github-star]
 [![Tweet][twitter-badge]][twitter]
 
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 ## The problem
 
 Currently, each babel plugin in the babel ecosystem requires that you configure

--- a/other/docs/author.md
+++ b/other/docs/author.md
@@ -18,7 +18,7 @@ There are two parts to the `babel-macros` API:
 1. The filename convention
 2. The function you export
 
-**Filename**:
+### Filename
 
 The way that `babel-macros` determines whether to run a macro is based on the
 source string of the `import` or `require` statement. It must match this regex:
@@ -56,15 +56,24 @@ import Nice from 'nice.macro'
 import Sweet from 'sweet/macro'
 ```
 
-**Function API**:
+### Function API
 
 The macro you create should export a function. That function accepts a single
 parameter which is an object with the following properties:
 
-**state**: The state of the file being traversed. It's the second argument
+#### state
+
+The state of the file being traversed. It's the second argument
 you receive in a visitor function in a normal babel plugin.
 
-**references**: This is an object that contains arrays of all the references to
+#### babel
+
+This is the same thing you get as an argument to normal babel plugins.
+It is also the same thing you get if you `require('babel-core')`.
+
+#### references
+
+This is an object that contains arrays of all the references to
 things imported from macro keyed based on the name of the import. The items
 in each array are the paths to the references.
 

--- a/package.json
+++ b/package.json
@@ -8,19 +8,18 @@
     "test": "nps test",
     "precommit": "lint-staged && opt --in pre-commit --exec \"npm start validate\""
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "keywords": [],
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
     "all-contributors-cli": "^4.3.0",
-    "ast-pretty-print": "2.0.0",
+    "ast-pretty-print": "^2.0.0",
     "babel-cli": "^6.24.1",
+    "babel-core": "^6.25.0",
     "babel-jest": "^20.0.3",
-    "babel-plugin-tester": "3.2.2",
+    "babel-plugin-tester": "^3.2.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.5.1",
@@ -39,17 +38,11 @@
     "prettier-eslint-cli": "^4.0.2"
   },
   "lint-staged": {
-    "*.js": [
-      "prettier-eslint --write",
-      "git add"
-    ]
+    "*.js": ["prettier-eslint --write", "git add"]
   },
   "jest": {
     "testEnvironment": "node",
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/fixtures/"
-    ],
+    "testPathIgnorePatterns": ["/node_modules/", "/fixtures/"],
     "coverageThreshold": {
       "global": {
         "branches": 100,

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,6 +1,7 @@
 import path from 'path'
 // eslint-disable-next-line
 import fakeMacro from 'fake/macro';
+import babel from 'babel-core'
 import pluginTester from 'babel-plugin-tester'
 import plugin from '../'
 
@@ -95,7 +96,9 @@ pluginTester({
         expect(fakeMacro).toHaveBeenCalledWith({
           references: expect.any(Object),
           state: expect.any(Object),
+          babel: expect.any(Object),
         })
+        expect(fakeMacro.mock.calls[0].babel).toBe(babel)
       },
     },
   ]),

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const macrosRegex = /[./]macro(\.js)?$/
 
 module.exports = macrosPlugin
 
-function macrosPlugin() {
+function macrosPlugin(babel) {
   return {
     name: 'macros',
     visitor: {
@@ -26,7 +26,7 @@ function macrosPlugin() {
             s.type === 'ImportDefaultSpecifier' ? 'default' : s.imported.name,
         }))
         const source = path.node.source.value
-        applyMacros({path, imports, source, state})
+        applyMacros({path, imports, source, state, babel})
         path.remove()
       },
       CallExpression(path, state) {
@@ -53,6 +53,7 @@ function macrosPlugin() {
           imports: [{localName: name, importedName: 'default'}],
           source,
           state,
+          babel,
         })
         path.parentPath.remove()
       },
@@ -60,7 +61,7 @@ function macrosPlugin() {
   }
 }
 
-function applyMacros({path, imports, source, state}) {
+function applyMacros({path, imports, source, state, babel}) {
   const {file: {opts: {filename}}} = state
   let hasReferences = false
   const referencePathsByImportName = imports.reduce(
@@ -84,6 +85,7 @@ function applyMacros({path, imports, source, state}) {
   macros({
     references: referencePathsByImportName,
     state,
+    babel,
   })
 }
 


### PR DESCRIPTION
This forwards the `babel` argument to each macro applied. This makes it easier to write a macro so you don't have to add `babel-core` to your dependencies yourself if you wouldn't otherwise need it.
