### PR TITLE
fix: show correct npm url for macros with a slash

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -55,6 +55,16 @@
       "contributions": [
         "ideas"
       ]
+    },
+    {
+      "login": "mitchellhamilton",
+      "name": "Mitchell Hamilton",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/11481355?v=4",
+      "profile": "https://hamil.town",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Enables zero-config, importable babel plugins
 [![downloads][downloads-badge]][npmchart]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -237,8 +237,8 @@ turned into macros.
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/babel-macros/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/babel-macros/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/babel-macros/commits?author=kentcdodds "Tests") | [<img src="https://avatars1.githubusercontent.com/u/18808?v=3" width="100px;"/><br /><sub>Sunil Pai</sub>](https://github.com/threepointone)<br />[🤔](#ideas-threepointone "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/1341513?v=3" width="100px;"/><br /><sub>Stephen Scott</sub>](http://suchipi.com/)<br />[💬](#question-suchipi "Answering Questions") [📖](https://github.com/kentcdodds/babel-macros/commits?author=suchipi "Documentation") | [<img src="https://avatars1.githubusercontent.com/u/767261?v=4" width="100px;"/><br /><sub>Michiel Dral</sub>](http://twitter.com/dralletje)<br />[🤔](#ideas-dralletje "Ideas, Planning, & Feedback") | [<img src="https://avatars2.githubusercontent.com/u/662750?v=4" width="100px;"/><br /><sub>Kye Hohenberger</sub>](https://github.com/tkh44)<br />[🤔](#ideas-tkh44 "Ideas, Planning, & Feedback") |
-| :---: | :---: | :---: | :---: | :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/babel-macros/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/babel-macros/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/babel-macros/commits?author=kentcdodds "Tests") | [<img src="https://avatars1.githubusercontent.com/u/18808?v=3" width="100px;"/><br /><sub>Sunil Pai</sub>](https://github.com/threepointone)<br />[🤔](#ideas-threepointone "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/1341513?v=3" width="100px;"/><br /><sub>Stephen Scott</sub>](http://suchipi.com/)<br />[💬](#question-suchipi "Answering Questions") [📖](https://github.com/kentcdodds/babel-macros/commits?author=suchipi "Documentation") | [<img src="https://avatars1.githubusercontent.com/u/767261?v=4" width="100px;"/><br /><sub>Michiel Dral</sub>](http://twitter.com/dralletje)<br />[🤔](#ideas-dralletje "Ideas, Planning, & Feedback") | [<img src="https://avatars2.githubusercontent.com/u/662750?v=4" width="100px;"/><br /><sub>Kye Hohenberger</sub>](https://github.com/tkh44)<br />[🤔](#ideas-tkh44 "Ideas, Planning, & Feedback") | [<img src="https://avatars1.githubusercontent.com/u/11481355?v=4" width="100px;"/><br /><sub>Mitchell Hamilton</sub>](https://hamil.town)<br />[💻](https://github.com/kentcdodds/babel-macros/commits?author=mitchellhamilton "Code") [⚠️](https://github.com/kentcdodds/babel-macros/commits?author=mitchellhamilton "Tests") |
+| :---: | :---: | :---: | :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/__mocks__/error-thrower/macro.js
+++ b/__mocks__/error-thrower/macro.js
@@ -1,0 +1,8 @@
+// const printAST = require('ast-pretty-print')
+const {createMacro} = require('../../src')
+
+module.exports = createMacro(evalMacro)
+
+function evalMacro() {
+  throw new Error('not helpful')
+}

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -42,6 +42,17 @@ Error: <PROJECT_ROOT>/src/__tests__/index.js: error-thrower.macro: not helpful L
 
 `;
 
+exports[`appends the npm URL for errors thrown by node modules with a slash 1`] = `
+
+import errorThrower from 'error-thrower/macro'
+errorThrower('hi')
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+Error: <PROJECT_ROOT>/src/__tests__/index.js: error-thrower/macro: not helpful Learn more: https://www.npmjs.com/package/error-thrower
+
+`;
+
 exports[`does nothing but remove macros if it is unused 1`] = `
 
 import foo from './some-macros-that-doesnt-even-need-to-exist.macro'

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -135,6 +135,15 @@ pluginTester({
         errorThrower('hi')
       `,
     },
+    {
+      title:
+        'appends the npm URL for errors thrown by node modules with a slash',
+      error: true,
+      code: `
+        import errorThrower from 'error-thrower/macro'
+        errorThrower('hi')
+      `,
+    },
   ],
 })
 

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,10 @@ function applyMacros({path, imports, source, state, babel}) {
     }
     error.message = `${source}: ${error.message}`
     if (!isRelative) {
-      error.message = `${error.message} Learn more: https://www.npmjs.com/package/${source}`
+      error.message = `${error.message} Learn more: https://www.npmjs.com/package/${source.replace(
+        /(\/.*)/g,
+        '',
+      )}`
     }
     throw error
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fix npm urls with macros that have slashes. e.g. `emotion/macro` Previously, the npm url would be https://www.npmjs.com/package/emotion/macro, now it will be https://www.npmjs.com/package/emotion
<!-- Why are these changes necessary? -->
**Why**:
Because the pages with the slashes don't exist.
<!-- How were these changes implemented? -->
**How**:
```js
.replace(/(\/.*)/g, '')
```

<!-- feel free to add additional comments -->
