### PR TITLE
Fixed issue with configName never being found in getConfig function

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -74,6 +74,16 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "PiereDome",
+      "name": "Brian Pedersen",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/1903016?v=4",
+      "profile": "https://github.com/PiereDome",
+      "contributions": [
+        "code",
+        "doc"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Enables zero-config, importable babel plugins
 [![downloads][downloads-badge]][npmchart]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -256,6 +256,7 @@ Thanks goes to these people ([emoji key][emojis]):
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 | [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/babel-macros/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/babel-macros/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/babel-macros/commits?author=kentcdodds "Tests") | [<img src="https://avatars1.githubusercontent.com/u/18808?v=3" width="100px;"/><br /><sub>Sunil Pai</sub>](https://github.com/threepointone)<br />[🤔](#ideas-threepointone "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/1341513?v=3" width="100px;"/><br /><sub>Stephen Scott</sub>](http://suchipi.com/)<br />[💬](#question-suchipi "Answering Questions") [📖](https://github.com/kentcdodds/babel-macros/commits?author=suchipi "Documentation") | [<img src="https://avatars1.githubusercontent.com/u/767261?v=4" width="100px;"/><br /><sub>Michiel Dral</sub>](http://twitter.com/dralletje)<br />[🤔](#ideas-dralletje "Ideas, Planning, & Feedback") | [<img src="https://avatars2.githubusercontent.com/u/662750?v=4" width="100px;"/><br /><sub>Kye Hohenberger</sub>](https://github.com/tkh44)<br />[🤔](#ideas-tkh44 "Ideas, Planning, & Feedback") | [<img src="https://avatars1.githubusercontent.com/u/11481355?v=4" width="100px;"/><br /><sub>Mitchell Hamilton</sub>](https://hamil.town)<br />[💻](https://github.com/kentcdodds/babel-macros/commits?author=mitchellhamilton "Code") [⚠️](https://github.com/kentcdodds/babel-macros/commits?author=mitchellhamilton "Tests") | [<img src="https://avatars1.githubusercontent.com/u/1288694?v=4" width="100px;"/><br /><sub>Justin Hall</sub>](https://github.com/wKovacs64)<br />[📖](https://github.com/kentcdodds/babel-macros/commits?author=wKovacs64 "Documentation") |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [<img src="https://avatars3.githubusercontent.com/u/1903016?v=4" width="100px;"/><br /><sub>Brian Pedersen</sub>](https://github.com/PiereDome)<br />[💻](https://github.com/kentcdodds/babel-macros/commits?author=PiereDome "Code") [📖](https://github.com/kentcdodds/babel-macros/commits?author=PiereDome "Documentation") |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,6 @@ function createMacro(macro, options = {}) {
   }
   macroWrapper.isBabelMacro = true
   macroWrapper.options = options
-  macroWrapper.configName = options.configName
   return macroWrapper
 
   function macroWrapper(args) {
@@ -160,7 +159,7 @@ function applyMacros({path, imports, source, state, babel}) {
 
 // eslint-disable-next-line consistent-return
 function getConfig(macro, filename, source) {
-  if (macro.configName) {
+  if (macro.options.configName) {
     try {
       // lazy-loading it here to avoid perf issues of loading it up front.
       // No I did not measure. Yes I'm a bad person.
@@ -175,12 +174,13 @@ function getConfig(macro, filename, source) {
         sync: true,
       }).load(filename)
       if (loaded) {
-        return loaded.config[macro.configName]
+        return loaded.config[macro.options.configName]
       }
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(
-        `There was an error trying to load the config "${macro.configName}" ` +
+        `There was an error trying to load the config "${macro.options
+          .configName}" ` +
           `for the macro imported from "${source}. ` +
           `Please see the error thrown for more information.`,
       )

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ function createMacro(macro, options = {}) {
   }
   macroWrapper.isBabelMacro = true
   macroWrapper.options = options
+  macroWrapper.configName = options.configName
   return macroWrapper
 
   function macroWrapper(args) {


### PR DESCRIPTION
**What**:
Config setup (in package.json, babel-macros.config.js, etc...) was never being picked up and passed to the macros

**Why**:
The experimental option of configs won't work

**How**:
I added the property of `configName` to `macroWrapper` in the `createMacro` function. We could do this in the `getConfig` function instead and change the `macro.configName` to `macro.options.configName`

Let me know if you would prefer the configName to remain nested in the options of the macroWrapper and I can make that code change
